### PR TITLE
Fix Google Dorking: Replace google with googlesearch-python

### DIFF
--- a/enumit.py
+++ b/enumit.py
@@ -105,7 +105,7 @@ def search_google(filetype_extention):
         logging.debug("started google search function")
     logging.info("searching google for: %s", google_query)
 
-    google_results = search(query=google_query)
+    google_results = search(google_query, num_results=20)
 
     for uri in google_results:
         if logging.level_debug():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "absl-py>=2.3.1",
-    "google>=3.0.0",
+    "googlesearch-python>=1.3.0",
     "nslookup>=1.8.1",
     "pycrtsh>=0.3.13",
     "shodan>=1.31.0",


### PR DESCRIPTION
As author is aware that current dependency `google>=3.0.0` is broken/outdated and returns no results for queries. This PR replaces it with `googlesearch-python`, which is actively maintained.
**Changes:**
- Replaced `google` dependency with `googlesearch-python` in `pyproject.toml`.
- Updated `enumit.py` to use the `search()` function from the new library (switched from keyword argument `query` to positional argument).
**Verification:**
Verified locally on (Mac m1) that the tool now successfully queries Google and returns results.